### PR TITLE
Improve unknown type error msg by including the type

### DIFF
--- a/packages/jest-get-type/src/index.ts
+++ b/packages/jest-get-type/src/index.ts
@@ -57,7 +57,7 @@ export function getType(value: unknown): ValueType {
     return 'symbol';
   }
 
-  throw new Error(`value of unknown type: ${value}`);
+  throw new Error(`value of unknown type: ${typeof value} (${value})`);
 }
 
 export const isPrimitive = (value: unknown): boolean => Object(value) !== value;


### PR DESCRIPTION
## Summary

The error message for an unknown type is vague and unhelpful- it tells you the value, but not the value's type.
This change includes the type and the value, which is more helpful when trying to find out what type went unhandled.